### PR TITLE
fix: Use choices in the small images theme

### DIFF
--- a/src/Resources/views/Form/small_images_theme.html.twig
+++ b/src/Resources/views/Form/small_images_theme.html.twig
@@ -15,7 +15,7 @@
                     {% set source_path = option.images.first.path %}
                     {% set path = source_path|imagine_filter(filter|default('monsieurbiz_sylius_advanced_option_tiny_thumbnail')) %}
                 {% else %}
-                    {% set path = '//placehold.it/400x300' %}
+                    {% set path = '//via.placeholder.com/32x32?text=' ~ choice.label %}
                 {% endif %}
 
                 <label style="display: inline-block;">


### PR DESCRIPTION
Use the `form.var.choices` to display the enabled options (if this feature is enabled):

![image](https://user-images.githubusercontent.com/465524/139137462-cba654a2-ea96-44d1-baf2-9f4f1a0fade4.png)

![image](https://user-images.githubusercontent.com/465524/139137635-9db54415-a29c-4fff-891d-552cc65935af.png)

An an the `checked` attribute on the radio input